### PR TITLE
Only add to ipynb pages, hide from search results

### DIFF
--- a/src/sphinx_thebe/__init__.py
+++ b/src/sphinx_thebe/__init__.py
@@ -297,8 +297,8 @@ if not hasattr(matplotlib.RcParams, "_get"):
             node.insert(0, nodes.raw(text=matplotlib_patch_html, format="html"))
             break
         else:
-            # Fallback: if no section found, append to doctree
-            doctree.append(nodes.raw(text=matplotlib_patch_html, format="html"))
+            # Fallback: if no section found, insert at top of doctree
+            doctree.insert(0, nodes.raw(text=matplotlib_patch_html, format="html"))
 
 
 def _split_repo_url(url):

--- a/src/sphinx_thebe/__init__.py
+++ b/src/sphinx_thebe/__init__.py
@@ -219,7 +219,7 @@ if not hasattr(matplotlib.RcParams, "_get"):
 </div></div></div></div>"""
         
         # Insert the patch cell at the beginning of the document
-        doctree.insert(0, nodes.raw(text=matplotlib_patch_code, format="html"))
+        doctree.insert(0, nodes.raw(text=matplotlib_patch_html, format="html"))
 
     # Codemirror syntax
     cm_language = kernel_name

--- a/src/sphinx_thebe/__init__.py
+++ b/src/sphinx_thebe/__init__.py
@@ -205,15 +205,15 @@ def update_thebe_context(app, doctree, docname):
     is_python_kernel = "python" in kernel_name_lower or kernel_name_lower.startswith("py") or "-py" in kernel_name_lower or kernel_name_lower.startswith("ipy")
     
     if config_thebe.get("use_thebe_lite", False) and is_python_kernel and _has_thebe_cells(doctree):
-        matplotlib_patch_code = """# Matplotlib compatibility patch for Pyodide
-import matplotlib
+        # Minimal patch code without comments to reduce search noise
+        matplotlib_patch_code = """import matplotlib
 if not hasattr(matplotlib.RcParams, "_get"):
     matplotlib.RcParams._get = dict.get"""
         
         # Create a hidden initialization cell with the patch
-        # This cell will auto-execute but remain hidden from users and search indexing
+        # This cell will auto-execute but remain hidden from users
         matplotlib_patch_html = f"""
-<div class="cell docutils container tag_thebe-remove-input-init" style="display: none;" aria-hidden="true">
+<div class="cell docutils container tag_thebe-remove-input-init">
 <div class="cell_input docutils container">
 <div class="highlight-ipython3 notranslate"><div class="highlight"><pre>{matplotlib_patch_code}</pre>
 </div></div></div></div>"""

--- a/src/sphinx_thebe/__init__.py
+++ b/src/sphinx_thebe/__init__.py
@@ -464,6 +464,7 @@ def setup(app):
     app.add_css_file("thebe.css")
     app.add_css_file("code.css")
     app.add_css_file("dark_mode_widget.css")
+    app.add_css_file("thebe-button-patch.css")
 
     # ThebeButtonNode is the button that activates thebe
     # and is only rendered for the HTML builder

--- a/src/sphinx_thebe/_static/sphinx-thebe-lite.js
+++ b/src/sphinx_thebe/_static/sphinx-thebe-lite.js
@@ -407,6 +407,16 @@ var initThebe = async () => {
     document.querySelector(".thebe-launch-button")
   );
 
+  // Remove any extra empty thebe-launch-button elements that may have been auto-generated
+  // Keep only the one we just moved to the header
+  const allButtons = document.querySelectorAll(".thebe-launch-button");
+  allButtons.forEach((button, index) => {
+    // Skip the first button (the one in the header)
+    if (index > 0 && button.innerText.trim() === "") {
+      button.remove();
+    }
+  });
+
   console.log("[sphinx-thebe]: Loading thebe...");
   document.querySelector(".thebe-launch-button ").innerText = thebeLoadingThebe;
 

--- a/src/sphinx_thebe/_static/sphinx-thebe-lite.js
+++ b/src/sphinx_thebe/_static/sphinx-thebe-lite.js
@@ -407,16 +407,6 @@ var initThebe = async () => {
     document.querySelector(".thebe-launch-button")
   );
 
-  // Remove any extra empty thebe-launch-button elements that may have been auto-generated
-  // Keep only the one we just moved to the header
-  const allButtons = document.querySelectorAll(".thebe-launch-button");
-  allButtons.forEach((button, index) => {
-    // Skip the first button (the one in the header)
-    if (index > 0 && button.innerText.trim() === "") {
-      button.remove();
-    }
-  });
-
   console.log("[sphinx-thebe]: Loading thebe...");
   document.querySelector(".thebe-launch-button ").innerText = thebeLoadingThebe;
 
@@ -488,6 +478,16 @@ var initThebe = async () => {
   updateThebeButtonStatus(thebePythonReady, false);
 
   moveHideInputOutput();
+  
+  // Clean up any extra empty launch buttons that may have been created
+  // This removes auto-generated buttons from the theme
+  const allButtons = document.querySelectorAll(".thebe-launch-button");
+  allButtons.forEach((button, index) => {
+    // Keep only the first button (in the header), remove empty extras
+    if (index > 0) {
+      button.remove();
+    }
+  });
 };
 
 // Helper function to munge the language name

--- a/src/sphinx_thebe/_static/thebe-button-patch.css
+++ b/src/sphinx_thebe/_static/thebe-button-patch.css
@@ -1,0 +1,3 @@
+button.thebe-launch-button:empty {
+    display: none;
+}


### PR DESCRIPTION
# Matplotlib Patch Implementation Summary

## Changes Made

### 1. **Optimized patch injection**
- Only inject the matplotlib patch on pages that:
  - Use `thebe-lite` mode
  - Have a Python kernel
  - **Actually contain code cells** (Jupyter notebook cells or code blocks with `:class: thebe`)
- Plain markdown pages without code cells are not affected
- Before: https://mude.citg.tudelft.nl/book/2025/modelling/overview.html
- After: https://mude.citg.tudelft.nl/book/fix/modelling/overview.html

### 2. **placement of patch**
- The matplotlib patch initialization cell was being inserted at the absolute beginning of the document (`doctree.insert(0, ...)`),. This is changed to insert the patch cell as the first child of the first `<section>` node, rather than at the document root.

## 3. Remove extra empty Thebe launch button from page content
- After initiating on pages with code cells with `thebe-remove-input-init`, an empty `<button class="thebe-launch-button"></button>` element was appearing in the page content (after the heading), in addition to the functional button in the toolbar.
- The Sphinx Book Theme automatically generates launch buttons when it detects Thebe-enabled cells (https://github.com/executablebooks/sphinx-book-theme/blob/master/src/sphinx_book_theme/assets/scripts/index.js#L148). This button was being added dynamically during or after Thebe initialization, creating a duplicate.
- Added cleanup code at the end of `initThebe()` in `sphinx-thebe-lite.js` that:
   1. Scans for all `.thebe-launch-button` elements after initialization completes
   2. Removes any buttons beyond the first one (which is in the header toolbar)
- Before: https://mude.citg.tudelft.nl/book/2025/numerical_methods_for_PDEs/advection_diffusion_eq.html
- After: https://mude.citg.tudelft.nl/book/fix/numerical_methods_for_PDEs/advection_diffusion_eq.html